### PR TITLE
Fix website app blank page

### DIFF
--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -8,6 +8,7 @@
   </head>
   <body class="bg-base-100 text-base-700">
     <div id="root"></div>
+    <p><a href="../../index.html">Back to app index</a></p>
     <script type="module" src="./src/index.jsx"></script>
   </body>
 </html>

--- a/apps/website/src/index.jsx
+++ b/apps/website/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { HashRouter, Routes, Route, Link } from 'react-router-dom';
 import '../src/styles/globals.css';
 import Home from './pages/Home.jsx';
 import Projects from './pages/Projects.jsx';
@@ -27,7 +27,7 @@ function Navbar() {
 
 function App() {
   return (
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <HashRouter>
       <Navbar />
       <div className="container mx-auto px-4">
         <Routes>
@@ -40,7 +40,7 @@ function App() {
           <Route path="/insights" element={<Insights />} />
         </Routes>
       </div>
-    </BrowserRouter>
+    </HashRouter>
   );
 }
 


### PR DESCRIPTION
## Summary
- use `HashRouter` for the website app so routes work when served from any path
- add "Back to app index" link in website `index.html`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861c342f8ac8332942fd2b0a898ff0b