### PR TITLE
Fix GitHub Pages trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: Deploy to GitHub Pages
 on:
   push:
-    branches: ["**"]
+    branches:
+      - main
+  workflow_dispatch:
 permissions:
   contents: read
   pages: write


### PR DESCRIPTION
## Summary
- only trigger deployment on `main`
- allow manual dispatch for GitHub Pages deploy

## Testing
- `npm test -- --run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686439162638833299c105d2cd533c12