### PR TITLE
Add tests for additional apps

### DIFF
--- a/apps/functors-as-objects/src/App.test.jsx
+++ b/apps/functors-as-objects/src/App.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import App from './App';
+
+test('renders heading', () => {
+  render(<App />);
+  const heading = screen.getByText(/Category Theory: Interactive Comparison/i);
+  expect(heading).toBeDefined();
+});

--- a/apps/presheaves-and-opposite-categories/src/App.test.tsx
+++ b/apps/presheaves-and-opposite-categories/src/App.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import App from './App';
+
+test('renders heading', () => {
+  render(<App />);
+  const heading = screen.getByText(/Presheaf Visualization/i);
+  expect(heading).toBeDefined();
+});

--- a/apps/push-out-pull-back/src/App.test.jsx
+++ b/apps/push-out-pull-back/src/App.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import App from './App';
+
+test('renders heading', () => {
+  render(<App />);
+  const heading = screen.getByText(/Category Theory: Interactive Comparison/i);
+  expect(heading).toBeDefined();
+});

--- a/apps/website/src/App.jsx
+++ b/apps/website/src/App.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import Home from './pages/Home.jsx';
+import Projects from './pages/Projects.jsx';
+import Sandbox from './pages/Sandbox.jsx';
+import AITools from './pages/AITools.jsx';
+import Systems from './pages/Systems.jsx';
+import Lifecycle from './pages/Lifecycle.jsx';
+import Insights from './pages/Insights.jsx';
+import './styles/globals.css';
+
+function Navbar() {
+  return (
+    <nav className="flex flex-wrap justify-around gap-x-8 p-4 border-b mb-4">
+      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/">Home</Link>
+      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/projects">Projects</Link>
+      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/sandbox">Tools Sandbox</Link>
+      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/ai-tools">AI Tools</Link>
+      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/systems">Systems Thinking</Link>
+      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/lifecycle">Lifecycle</Link>
+      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/insights">Insights</Link>
+      <a className="hover:text-accent-600 hover:underline decoration-2" href="../../app-index.html">App Index</a>
+    </nav>
+  );
+}
+
+export default function App() {
+  return (
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
+      <Navbar />
+      <div className="container mx-auto px-4">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/projects" element={<Projects />} />
+          <Route path="/sandbox" element={<Sandbox />} />
+          <Route path="/ai-tools" element={<AITools />} />
+          <Route path="/systems" element={<Systems />} />
+          <Route path="/lifecycle" element={<Lifecycle />} />
+          <Route path="/insights" element={<Insights />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
+  );
+}

--- a/apps/website/src/App.test.jsx
+++ b/apps/website/src/App.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import App from './App';
+
+test('renders heading', () => {
+  render(<App />);
+  const heading = screen.getByText(/^Welcome$/i);
+  expect(heading).toBeDefined();
+});

--- a/apps/website/src/index.jsx
+++ b/apps/website/src/index.jsx
@@ -1,48 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
-import '../src/styles/globals.css';
-import Home from './pages/Home.jsx';
-import Projects from './pages/Projects.jsx';
-import Sandbox from './pages/Sandbox.jsx';
-import AITools from './pages/AITools.jsx';
-import Systems from './pages/Systems.jsx';
-import Lifecycle from './pages/Lifecycle.jsx';
-import Insights from './pages/Insights.jsx';
-
-function Navbar() {
-  return (
-    <nav className="flex flex-wrap justify-around gap-x-8 p-4 border-b mb-4">
-      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/">Home</Link>
-      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/projects">Projects</Link>
-      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/sandbox">Tools Sandbox</Link>
-      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/ai-tools">AI Tools</Link>
-      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/systems">Systems Thinking</Link>
-      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/lifecycle">Lifecycle</Link>
-      <Link className="hover:text-accent-600 hover:underline decoration-2" to="/insights">Insights</Link>
-      <a className="hover:text-accent-600 hover:underline decoration-2" href="../../app-index.html">App Index</a>
-    </nav>
-  );
-}
-
-function App() {
-  return (
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
-      <Navbar />
-      <div className="container mx-auto px-4">
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/projects" element={<Projects />} />
-          <Route path="/sandbox" element={<Sandbox />} />
-          <Route path="/ai-tools" element={<AITools />} />
-          <Route path="/systems" element={<Systems />} />
-          <Route path="/lifecycle" element={<Lifecycle />} />
-          <Route path="/insights" element={<Insights />} />
-        </Routes>
-      </div>
-    </BrowserRouter>
-  );
-}
+import App from './App.jsx';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);


### PR DESCRIPTION
## Summary
- provide tests for `functors-as-objects`, `push-out-pull-back`, `presheaves-and-opposite-categories`, and `website` apps
- refactor website entry to expose an `App` component

## Testing
- `APP=functors-as-objects npm test -- --run`
- `APP=push-out-pull-back npm test -- --run`
- `APP=presheaves-and-opposite-categories npm test -- --run`
- `APP=website npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68650e4851a883329dfe1489d7ed6fba