### PR TITLE
Convert presheaves app to JSX

### DIFF
--- a/apps/presheaves-and-opposite-categories/src/App.jsx
+++ b/apps/presheaves-and-opposite-categories/src/App.jsx
@@ -4,17 +4,17 @@ import './App.css';
 
 const colors = ['white', '#f87171', '#60a5fa', '#34d399', '#fbbf24'];
 
-function nextColor(current: string) {
+function nextColor(current) {
   const idx = colors.indexOf(current);
   return colors[(idx + 1) % colors.length];
 }
 
 export default function PresheafVisualization() {
   const [showExample, setShowExample] = useState(false);
-  const [graphGColorings, setGraphGColorings] = useState<string[]>(['white', 'white', 'white']);
-  const [graphHColorings, setGraphHColorings] = useState<string[]>(['white', 'white']);
+  const [graphGColorings, setGraphGColorings] = useState(['white', 'white', 'white']);
+  const [graphHColorings, setGraphHColorings] = useState(['white', 'white']);
 
-  const resetGraphs = (advanced: boolean) => {
+  const resetGraphs = (advanced) => {
     if (advanced) {
       setGraphGColorings(['white', 'white', 'white']);
       setGraphHColorings(['white', 'white']);
@@ -30,7 +30,7 @@ export default function PresheafVisualization() {
     resetGraphs(adv);
   };
 
-  const changeColor = (graph: 'G' | 'H', index: number) => {
+  const changeColor = (graph, index) => {
     if (graph === 'G') {
       setGraphGColorings(prev => {
         const arr = [...prev];

--- a/apps/presheaves-and-opposite-categories/src/App.test.jsx
+++ b/apps/presheaves-and-opposite-categories/src/App.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { expect, test } from 'vitest';
-import App from './App';
+import App from './App.jsx';
 
 test('renders heading', () => {
   render(<App />);

--- a/apps/presheaves-and-opposite-categories/src/index.jsx
+++ b/apps/presheaves-and-opposite-categories/src/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import '../../../src/common/index.css';
-import App from './App.tsx';
+import App from './App.jsx';
 import reportWebVitals from '../../../src/common/reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
## Summary
- convert `App.tsx` to `App.jsx`
- update references and tests
- ensure presheaves app runs and tests pass as JSX

## Testing
- `APP=presheaves-and-opposite-categories npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865964d20b08332a9e8901ce07ec1a4