### PR TITLE
Move fibration example into app folder and fix asset/backlink paths

### DIFF
--- a/app-index.csv
+++ b/app-index.csv
@@ -13,4 +13,4 @@
 12,galois-adjoints,galois adjoints for project management rail upgrade demo,User,,"category theory, adjoints, project management, visualization",,
 14,composable-uncertainty-wiring,composable uncertainty wiring diagram for a co-design loop (power/cooling/footprint),User,,"category theory, uncertainty, wiring diagrams, co-design",,
 13,category_theory_construction_toolkit,category theory toolkit for construction systems engineering,User,,"category theory, construction, toolkit, systems",,
-15,fibration_example_v2.html,fibration-based milestone linking interactive example,User,,"fibration, milestones, linking",,
+15,fibration_example_v2,fibration-based milestone linking interactive example,User,,"fibration, milestones, linking",,

--- a/apps/fibration_example_v2/index.html
+++ b/apps/fibration_example_v2/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Fibration‑Based Milestone Linking — Interactive Toy Example</title>
-  <link rel="stylesheet" href="../common.css">
+  <link rel="stylesheet" href="../../common.css">
   <style>
     :root{
       --bg: #0b1020;
@@ -601,7 +601,7 @@
   </style>
 </head>
 <body>
-  <p><a href="../app-index.html">Back to app index</a></p>
+  <p><a href="../../app-index.html">Back to app index</a></p>
   <header>
     <div class="wrap">
       <h1>Fibration‑Based Milestone Linking — Interactive Toy Example</h1>


### PR DESCRIPTION
### Motivation
- Make the fibration example addressable as an app under `apps/` so the published URL resolves correctly.
- Ensure asset and index links remain correct after changing the file layout.

### Description
- Moved the standalone file `apps/fibration_example_v2.html` into the app folder as `apps/fibration_example_v2/index.html`.
- Updated the stylesheet reference in `apps/fibration_example_v2/index.html` from `../common.css` to `../../common.css` to match the new location.
- Updated the back link in `apps/fibration_example_v2/index.html` from `../app-index.html` to `../../app-index.html` so the app links back to the index page.
- Updated the `app-index.csv` entry to use `fibration_example_v2` (folder-based app) instead of the old `fibration_example_v2.html` filename.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982850c2d648332a211c66d0f74b60d)